### PR TITLE
Add minimal OS X support

### DIFF
--- a/c_src/statfs.h
+++ b/c_src/statfs.h
@@ -10,7 +10,14 @@
 #define __STATFS_DRV__
 
 #include <sys/statvfs.h>
+
+#ifdef __MACH__
+#include <sys/param.h>
+#include <sys/ucred.h>
+#include <sys/mount.h>
+#else
 #include <mntent.h>
+#endif
 
 #include "erl_nif.h"
 
@@ -29,14 +36,17 @@ ERL_NIF_TERM make_atom(ErlNifEnv* env, const char* name);
 ERL_NIF_TERM make_ok(statfs_st* st, ErlNifEnv* env, ERL_NIF_TERM data);
 ERL_NIF_TERM make_error(statfs_st* st, ErlNifEnv* env, const char* error);
 ERL_NIF_TERM make_statfs(statfs_st* st, ErlNifEnv* env, const struct statvfs* stat);
+#ifdef __MACH__
+ERL_NIF_TERM make_mount(statfs_st* st, ErlNifEnv* env, const struct statfs* stat);
+#else
 ERL_NIF_TERM make_mount(statfs_st* st, ErlNifEnv* env, const struct mntent* stat);
+#endif
 
 ERL_NIF_TERM make_f_flag(statfs_st* st, ErlNifEnv* env, const struct statvfs* stat);
-ERL_NIF_TERM make_mount_opts(statfs_st* st, ErlNifEnv, const struct mntent* ent);
+
 
 const char* resolve_errno(int err);
 
 ERL_NIF_TERM nif_statfs(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_mounts(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-
 #endif

--- a/c_src/util.c
+++ b/c_src/util.c
@@ -79,6 +79,21 @@ make_f_flag(statfs_st* st, ErlNifEnv* env, const struct statvfs* stat)
   return ret;
 }
 
+
+#ifdef __MACH__
+ERL_NIF_TERM
+make_mount(statfs_st* st, ErlNifEnv* env, const struct statfs* ent)
+{
+  return enif_make_tuple(env, 7, st->atom_mount,
+                         enif_make_string(env, ent->f_mntfromname, ERL_NIF_LATIN1),
+                         enif_make_string(env, ent->f_mntonname, ERL_NIF_LATIN1),
+                         enif_make_string(env, ent->f_fstypename, ERL_NIF_LATIN1),
+                         // We don't support the following field on OS X
+                         enif_make_string(env, "", ERL_NIF_LATIN1),
+                         enif_make_int(env, 0),
+                         enif_make_int(env, 0));
+}
+#else
 ERL_NIF_TERM
 make_mount(statfs_st* st, ErlNifEnv* env, const struct mntent* ent)
 {
@@ -90,3 +105,4 @@ make_mount(statfs_st* st, ErlNifEnv* env, const struct mntent* ent)
 			 enif_make_int(env, ent->mnt_freq),
 			 enif_make_int(env, ent->mnt_passno));
 }
+#endif

--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,11 @@
 % -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
 
-{port_specs, 
- [{".*-linux", "priv/statfs.so", 
+{port_specs,
+ [{".*", "priv/statfs.so",
    ["c_src/*.c"],
-   [{env, 
-     [{"CFLAGS", 
+   [{env,
+     [{"CFLAGS",
        "$CFLAGS -std=c99 -g -Wall -Werror -O3"}]}
    ]}
  ]}.


### PR DESCRIPTION
Previously, the nif_mount function only supported Linux as it used 
the getmntent function. This commit adds an alternate implementation of
nif_mount which uses the getmntinfo function available on OS X.

While the getmntinfo returns data about the flags, I haven't
implemented parsing for them here as they don't seem to be used.

Signed-off-by: Steven Danna <steve@chef.io>